### PR TITLE
feat: CLI-Based Functionality for MySQL Limited Data Dump Script

### DIFF
--- a/dump_tables.sh
+++ b/dump_tables.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Function to display help message
+show_help() {
+    echo "Usage: $0 -d <database_name> -u <username> -p <password> -o <output_file>"
+    echo ""
+    echo "Options:"
+    echo "  -d  Database name"
+    echo "  -u  MySQL username"
+    echo "  -p  MySQL password"
+    echo "  -o  Output file (optional, default: limited_dump.sql)"
+    echo "  -h  Display this help message"
+}
+
+# Default output file
+OUTPUT_FILE="limited_dump.sql"
+
+# Parse command-line arguments
+while getopts ":d:u:p:o:h" opt; do
+    case ${opt} in
+        d )
+            DB_NAME=$OPTARG
+            ;;
+        u )
+            DB_USER=$OPTARG
+            ;;
+        p )
+            DB_PASS=$OPTARG
+            ;;
+        o )
+            OUTPUT_FILE=$OPTARG
+            ;;
+        h )
+            show_help
+            exit 0
+            ;;
+        \? )
+            echo "Invalid option: -$OPTARG" >&2
+            show_help
+            exit 1
+            ;;
+        : )
+            echo "Option -$OPTARG requires an argument." >&2
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Check if required arguments are provided
+if [ -z "$DB_NAME" ] || [ -z "$DB_USER" ] || [ -z "$DB_PASS" ]; then
+    echo "Error: Database name, username, and password are required."
+    show_help
+    exit 1
+fi
+
+# Clear output file before writing
+> "$OUTPUT_FILE"
+
+# Get list of tables
+tables=$(mysql -u "$DB_USER" -p"$DB_PASS" -D "$DB_NAME" -e "SHOW TABLES;" | awk '{ print $1}' | grep -v '^Tables')
+
+# Dump 10 rows from each table
+for table in $tables; do
+    echo "Dumping table: $table"
+    mysqldump -u "$DB_USER" -p"$DB_PASS" --no-create-info --skip-lock-tables --compact --quick \
+        --where="TRUE LIMIT 10" "$DB_NAME" "$table" >> "$OUTPUT_FILE"
+done
+
+echo "Dump completed. Output saved to $OUTPUT_FILE."

--- a/index.sh
+++ b/index.sh
@@ -32,5 +32,102 @@ then
     exit 1
 fi
 
+# Function to prompt user input with a default value
+prompt_input() {
+    read -p "$1 [$2]: " input
+    echo "${input:-$2}"
+}
+
+# Function to prompt user input with a list of options
+prompt_option() {
+    local options=("$@")
+
+    select opt in "${options[@]}"; do
+        if [ -n "$opt" ]; then
+            echo "$opt"
+            break
+        else
+            echo "Invalid option. Please choose a number between 1 and ${#options[@]}."
+        fi
+    done
+}
+
+# Choose backup option
+echo "Please choose a backup option:"
+BACKUP_DEST=$(prompt_option "GMAIL" "S3_BUCKET")
+
+# Collect details based on the chosen backup option
+if [[ $BACKUP_DEST == "GMAIL" ]]; then
+    MAIL_USER=$(prompt_input "Enter MAIL_USER")
+    MAIL_PASSWORD=$(prompt_input "Enter MAIL_PASSWORD")
+elif [[ $BACKUP_DEST == "S3_BUCKET" ]]; then
+    AWS_ACCESS_KEY_ID=$(prompt_input "Enter AWS_ACCESS_KEY_ID")
+    AWS_SECRET_ACCESS_KEY=$(prompt_input "Enter AWS_SECRET_ACCESS_KEY")
+    AWS_S3_BUCKET_NAME=$(prompt_input "Enter AWS_S3_BUCKET_NAME")
+    AWS_REGION=$(prompt_input "Enter AWS_REGION")
+else
+    echo "Invalid backup option selected."
+    exit 1
+fi
+
+
+# Choose backup notification
+echo "Please choose a backup notification option:"
+BACKUP_NOTIFICATION=$(prompt_option "SLACK" "DISCORD")
+
+# Collect notification details based on the chosen notification option
+if [[ $BACKUP_NOTIFICATION == "SLACK" ]]; then
+    SLACK_WEBHOOK_URL=$(prompt_input "Enter SLACK_WEBHOOK_URL")
+elif [[ $BACKUP_NOTIFICATION == "DISCORD" ]]; then
+    DISCORD_WEBHOOK_URL=$(prompt_input "Enter DISCORD_WEBHOOK_URL")
+else
+    echo "Invalid notification option selected."
+    exit 1
+fi
+
+
+POSTGRES_DB_HOST=$(prompt_input "Enter Postgres DB host" "127.0.0.1")
+POSTGRES_DB_NAME=$(prompt_input "Enter Postgres DB name" "postgres")
+POSTGRES_DB_USER=$(prompt_input "Enter Postgres DB user" "postgres")
+POSTGRES_DB_PASSWORD=$(prompt_input "Enter Postgres DB password" "postgres")
+
+MYSQL_HOST=$(prompt_input "Enter MySQL host" "127.0.0.1")
+MYSQL_DB_NAME=$(prompt_input "Enter MySQL DB name" "mysqldb")
+MYSQL_DB_USER=$(prompt_input "Enter MySQL DB user" "root")
+MYSQL_DB_PASSWORD=$(prompt_input "Enter MySQL DB password" "my-secret-pw")
+
+
+# Create the .env file
+cat <<EOF > .env
+#MAIL
+MAIL_USER='$MAIL_USER'
+MAIL_PASSWORD='$MAIL_PASSWORD'
+
+#BACKUP_CONFIG
+BACKUP_DEST='$BACKUP_DEST'
+BACKUP_NOTIFICATION='$BACKUP_NOTIFICATION'
+DISCORD_WEBHOOK_URL='$DISCORD_WEBHOOK_URL'
+SLACK_WEBHOOK_URL='$SLACK_WEBHOOK_URL'
+
+# POSTGRES DATABASE CONFIGURATION
+POSTGRES_DB_HOST='$POSTGRES_DB_HOST'
+POSTGRES_DB_NAME='$POSTGRES_DB_NAME'
+POSTGRES_DB_USER='$POSTGRES_DB_USER'
+POSTGRES_DB_PASSWORD='$POSTGRES_DB_PASSWORD'
+
+# MYSQL DATABASE CONFIGURATION
+MYSQL_HOST='$MYSQL_HOST'
+MYSQL_DB_NAME='$MYSQL_DB_NAME'
+MYSQL_DB_USER='$MYSQL_DB_USER'
+MYSQL_DB_PASSWORD='$MYSQL_DB_PASSWORD'
+
+#AWS S3 CONFIGURATION
+AWS_ACCESS_KEY_ID='$AWS_ACCESS_KEY_ID'
+AWS_SECRET_ACCESS_KEY='$AWS_SECRET_ACCESS_KEY'
+AWS_S3_BUCKET_NAME='$AWS_S3_BUCKET_NAME'
+AWS_REGION='$AWS_REGION'
+EOF
+
+echo ".env file created successfully!"
 
 pnpm install && pnpm start


### PR DESCRIPTION
This PR adds command-line interface (CLI) support to the existing MySQL limited data dump script. Users can now specify the database name, MySQL username, password, and output file directly through command-line arguments, improving the script's flexibility and usability.

## Changes Introduced:
CLI Argument Parsing:
Added support for -d (database name), -u (username), -p (password), and -o (output file) options.
Provided a -h option to display a help message with usage instructions.

Improved Flexibility:
Users can specify different databases, usernames, and output files directly from the command line.
The script will validate the required arguments and provide helpful error messages if any required arguments are missing.

Default Behavior:
If no output file is specified, the script defaults to limited_dump.sql.

Help Functionality:
A help function was added to guide users on how to use the script.

Usage Examples:
```
# Basic usage with all options specified
./dump_tables.sh -d location -u root -p iamsohappy -o limited_dump.sql

# Usage with default output file
./dump_tables.sh -d location -u root -p iamsohappy

# Display help
./dump_tables.sh -h
```
Additional Notes: Please let me know if there are any improvements or additional features you'd like to see related to this integration.
